### PR TITLE
支持 taro 所有的 postcss 配置

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,8 @@ module.exports = {
         'quote-props': ['error', 'as-needed'],
         'no-inner-declarations': 'off',
         'no-empty': 'off',
-        'react/react-in-jsx-scope': 'off'
+        'react/react-in-jsx-scope': 'off',
+        'no-unused-vars': ['error', { ignoreRestSiblings: true }]
     },
     overrides: [
         {

--- a/examples/with-postcss/README.md
+++ b/examples/with-postcss/README.md
@@ -1,0 +1,15 @@
+# Less 示例
+
+Next.js 框架本身不支持 Less，插件内部依赖 [next-with-less](https://github.com/elado/next-with-less) 来对其进行支持。
+
+## 执行 Next.js
+
+```bash
+yarn dev:nextjs
+```
+
+## 执行小程序
+
+```bash
+yarn dev:swan
+```

--- a/examples/with-postcss/babel.config.js
+++ b/examples/with-postcss/babel.config.js
@@ -1,0 +1,10 @@
+// babel-preset-taro 更多选项和默认值：
+// https://github.com/NervJS/taro/blob/next/packages/babel-preset-taro/README.md
+module.exports = {
+  presets: [
+    ['taro', {
+      framework: 'react',
+      ts: true
+    }]
+  ]
+}

--- a/examples/with-postcss/config/dev.js
+++ b/examples/with-postcss/config/dev.js
@@ -1,0 +1,9 @@
+module.exports = {
+  env: {
+    NODE_ENV: '"development"'
+  },
+  defineConstants: {
+  },
+  mini: {},
+  h5: {}
+}

--- a/examples/with-postcss/config/index.js
+++ b/examples/with-postcss/config/index.js
@@ -1,0 +1,86 @@
+const config = {
+    projectName: 'with-postcss',
+    date: '2022-4-16',
+    designWidth: 375,
+    deviceRatio: {
+        640: 1,
+        750: 1,
+        828: 1.81 / 2,
+        375: 2 / 1
+    },
+    sourceRoot: 'src',
+    outputRoot: 'dist',
+    plugins: [
+        ['tarojs-plugin-platform-nextjs', {
+            extraFiles: [
+                'postcss-plugins/**/*.js'
+            ]
+        }]
+    ],
+    env: {
+    },
+    copy: {
+        patterns: [
+        ],
+        options: {
+        }
+    },
+    framework: 'react',
+    mini: {
+        postcss: {
+            pxtransform: {
+                enable: true,
+                config: {
+
+                }
+            },
+            url: {
+                enable: true,
+                config: {
+                    limit: 1024 // 设定转换尺寸上限
+                }
+            },
+            cssModules: {
+                enable: false, // 默认为 false，如需使用 css modules 功能，则设为 true
+                config: {
+                    namingPattern: 'module', // 转换模式，取值为 global/module
+                    generateScopedName: '[name]__[local]___[hash:base64:5]'
+                }
+            }
+        }
+    },
+    h5: {
+        publicPath: '/',
+        staticDirectory: 'static',
+        postcss: {
+            autoprefixer: {
+                enable: true,
+                config: {
+                }
+            },
+            cssModules: {
+                enable: false, // 默认为 false，如需使用 css modules 功能，则设为 true
+                config: {
+                    namingPattern: 'module', // 转换模式，取值为 global/module
+                    generateScopedName: '[name]__[local]___[hash:base64:5]'
+                }
+            },
+            './postcss-plugins/red-color.js': {
+                enable: true,
+            }
+        },
+        router: {
+            mode: 'browser',
+            customRoutes: {
+                '/pages/index/index': '/'
+            }
+        }
+    }
+}
+
+module.exports = function (merge) {
+    if (process.env.NODE_ENV === 'development') {
+        return merge({}, config, require('./dev'))
+    }
+    return merge({}, config, require('./prod'))
+}

--- a/examples/with-postcss/config/prod.js
+++ b/examples/with-postcss/config/prod.js
@@ -1,0 +1,8 @@
+module.exports = {
+  env: {
+    NODE_ENV: '"production"'
+  },
+  defineConstants: {},
+  mini: {},
+  h5: {}
+}

--- a/examples/with-postcss/global.d.ts
+++ b/examples/with-postcss/global.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="@tarojs/taro" />
+
+declare module '*.png';
+declare module '*.gif';
+declare module '*.jpg';
+declare module '*.jpeg';
+declare module '*.svg';
+declare module '*.css';
+declare module '*.less';
+declare module '*.scss';
+declare module '*.sass';
+declare module '*.styl';
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    TARO_ENV: 'weapp' | 'swan' | 'alipay' | 'h5' | 'rn' | 'tt' | 'quickapp' | 'qq' | 'jd'
+  }
+}

--- a/examples/with-postcss/package.json
+++ b/examples/with-postcss/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "with-postcss",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build:weapp": "taro build --type weapp",
+    "build:swan": "taro build --type swan",
+    "build:alipay": "taro build --type alipay",
+    "build:tt": "taro build --type tt",
+    "build:h5": "taro build --type h5",
+    "build:rn": "taro build --type rn",
+    "build:qq": "taro build --type qq",
+    "build:jd": "taro build --type jd",
+    "build:quickapp": "taro build --type quickapp",
+    "build:nextjs": "taro build --type nextjs",
+    "dev:weapp": "npm run build:weapp -- --watch",
+    "dev:swan": "npm run build:swan -- --watch",
+    "dev:alipay": "npm run build:alipay -- --watch",
+    "dev:tt": "npm run build:tt -- --watch",
+    "dev:h5": "npm run build:h5 -- --watch",
+    "dev:rn": "npm run build:rn -- --watch",
+    "dev:qq": "npm run build:qq -- --watch",
+    "dev:jd": "npm run build:jd -- --watch",
+    "dev:quickapp": "npm run build:quickapp -- --watch",
+    "dev:nextjs": "npm run build:nextjs -- --watch"
+  },
+  "browserslist": [
+    "last 3 versions",
+    "Android >= 4.1",
+    "ios >= 8"
+  ],
+  "author": "SyMind",
+  "dependencies": {
+    "@babel/runtime": "^7.7.7",
+    "@tarojs/cli": "3.4.4",
+    "@tarojs/components": "3.4.4",
+    "@tarojs/plugin-framework-react": "3.4.4",
+    "@tarojs/react": "3.4.4",
+    "@tarojs/runtime": "3.4.4",
+    "@tarojs/taro": "3.4.4",
+    "next": "^12.1.5",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
+    "tarojs-plugin-platform-nextjs": "latest"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.8.0",
+    "@tarojs/mini-runner": "3.4.4",
+    "@tarojs/webpack-runner": "3.4.4",
+    "@types/react": "^17.0.2",
+    "@types/webpack-env": "^1.13.6",
+    "@typescript-eslint/eslint-plugin": "^4.15.1",
+    "@typescript-eslint/parser": "^4.15.1",
+    "babel-preset-taro": "3.4.4",
+    "typescript": "^4.1.0"
+  }
+}

--- a/examples/with-postcss/postcss-plugins/red-color.js
+++ b/examples/with-postcss/postcss-plugins/red-color.js
@@ -1,0 +1,15 @@
+const postcss = require('postcss')
+
+module.exports = () => {
+    return {
+        postcssPlugin: 'postcss-red-color',
+        Once(css) {
+            css.walkRules(rule => {
+                const decl = { prop: 'color', value: 'red' }
+                rule.append(decl)
+            })
+        }
+    }
+}
+
+module.exports.postcss = true

--- a/examples/with-postcss/project.config.json
+++ b/examples/with-postcss/project.config.json
@@ -1,0 +1,13 @@
+{
+  "miniprogramRoot": "./dist",
+  "projectname": "data",
+  "description": "数据请求示例",
+  "appid": "touristappid",
+  "setting": {
+    "urlCheck": true,
+    "es6": false,
+    "postcss": false,
+    "minified": false
+  },
+  "compileType": "miniprogram"
+}

--- a/examples/with-postcss/project.tt.json
+++ b/examples/with-postcss/project.tt.json
@@ -1,0 +1,9 @@
+{
+  "miniprogramRoot": "./",
+  "projectname": "data",
+  "appid": "testAppId",
+  "setting": {
+    "es6": false,
+    "minified": false
+  }
+}

--- a/examples/with-postcss/src/app.config.ts
+++ b/examples/with-postcss/src/app.config.ts
@@ -1,0 +1,11 @@
+export default defineAppConfig({
+  pages: [
+    'pages/index/index'
+  ],
+  window: {
+    backgroundTextStyle: 'light',
+    navigationBarBackgroundColor: '#fff',
+    navigationBarTitleText: 'WeChat',
+    navigationBarTextStyle: 'black'
+  }
+})

--- a/examples/with-postcss/src/app.less
+++ b/examples/with-postcss/src/app.less
@@ -1,0 +1,6 @@
+body {
+    padding: 0!important;
+    margin: 0!important;
+    font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji!important;
+    line-height: 1.5!important;
+}

--- a/examples/with-postcss/src/app.ts
+++ b/examples/with-postcss/src/app.ts
@@ -1,0 +1,20 @@
+import { Component } from 'react'
+import './app.less'
+
+class App extends Component {
+
+  componentDidMount () {}
+
+  componentDidShow () {}
+
+  componentDidHide () {}
+
+  componentDidCatchError () {}
+
+  // this.props.children 是将要会渲染的页面
+  render () {
+    return this.props.children
+  }
+}
+
+export default App

--- a/examples/with-postcss/src/index.html
+++ b/examples/with-postcss/src/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width,initial-scale=1,user-scalable=no" name="viewport">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-touch-fullscreen" content="yes">
+  <meta name="format-detection" content="telephone=no,address=no">
+  <meta name="apple-mobile-web-app-status-bar-style" content="white">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" >
+  <title></title>
+  <script>
+    !function(n){function e(){var e=n.document.documentElement,t=e.getBoundingClientRect().width;e.style.fontSize=t>=640?"40px":t<=320?"20px":t/320*20+"px"}n.addEventListener("resize",(function(){e()})),e()}(window);
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>

--- a/examples/with-postcss/src/pages/index/index.config.ts
+++ b/examples/with-postcss/src/pages/index/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: '首页'
+})

--- a/examples/with-postcss/src/pages/index/index.h5.tsx
+++ b/examples/with-postcss/src/pages/index/index.h5.tsx
@@ -1,0 +1,8 @@
+export { default } from './view';
+
+export async function getStaticProps() {
+    return {
+        props: {},
+        revalidate: 1
+    }
+}

--- a/examples/with-postcss/src/pages/index/index.module.less
+++ b/examples/with-postcss/src/pages/index/index.module.less
@@ -1,0 +1,20 @@
+// mixins
+.bordered {
+    border-top: dotted 1px black;
+    border-bottom: solid 2px black;
+}
+
+.a {
+    color: #111;
+    .bordered();
+}
+
+// functions
+@base: #f04615;
+@width: 1;
+
+.functions {
+    width: percentage(@width);
+    color: saturate(@base, 5%);
+    background-color: spin(lighten(@base, 25%), 8);
+}

--- a/examples/with-postcss/src/pages/index/index.tsx
+++ b/examples/with-postcss/src/pages/index/index.tsx
@@ -1,0 +1,7 @@
+import IndexView from './view';
+
+function Index() {
+  return <IndexView />
+}
+
+export default Index

--- a/examples/with-postcss/src/pages/index/view.tsx
+++ b/examples/with-postcss/src/pages/index/view.tsx
@@ -1,0 +1,11 @@
+import {View} from '@tarojs/components'
+import styles from './index.module.less';
+
+const IndexView = () => (
+    <>
+        <View className={styles.a}>混合（Mixins）</View>
+        <View className={styles.functions}>函数（Functions）</View>
+    </>
+);
+
+export default IndexView

--- a/examples/with-postcss/tsconfig.json
+++ b/examples/with-postcss/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "noImplicitAny": false,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "lib",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "rootDir": ".",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "include": ["./src", "global.d.ts"],
+  "compileOnSave": false
+}

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -58,6 +58,7 @@
         "next-with-less": "^2.0.5",
         "open": "^8.4.0",
         "postcss-pxtorem": "^6.0.0",
+        "resolve": "^1.22.4",
         "scss-bundle": "^3.1.2",
         "upath": "^2.0.1",
         "url-loader": "^4.1.1"

--- a/packages/nextjs/postcss/index.js
+++ b/packages/nextjs/postcss/index.js
@@ -1,6 +1,6 @@
 // 同步 Taro 项目中 packages/taro-webpack5-runner/src/postcss/postcss.h5.ts 中的逻辑
 const path = require('path')
-const { merge, cloneDeep } = require('lodash')
+const { merge } = require('lodash')
 const { sync } = require('resolve')
 
 const platform = 'h5'
@@ -76,21 +76,21 @@ const getPostCssConfig = getConfig => {
     }
     const pxtransformOption = merge({}, defaultPxtransformOption, pxtransform)
     if (isEnable(pxtransformOption)) {
-        plugins.push([require.resolve('postcss-pxtransform'), pxtransformOption])
+        plugins.push([require.resolve('postcss-pxtransform'), pxtransformOption.config || {}])
     }
     
     const htmlTransformOption = merge({}, defaultHtmltransformOption, htmltransform)
     if (isEnable(htmlTransformOption)) {
-        plugins.push([require.resolve('postcss-html-transform'), htmlTransformOption])
+        plugins.push([require.resolve('postcss-html-transform'), htmlTransformOption.config || {}])
     }
 
-    plugins.push([require.resolve('postcss-plugin-constparse'), cloneDeep(defaultConstparseOption)])
+    plugins.push([require.resolve('postcss-plugin-constparse'), defaultConstparseOption.config || {}])
 
     // TODO: 处理 postcss-alias 插件
 
     const urlOption = merge({}, defaultUrlOption, url)
     if (isEnable(urlOption)) {
-        plugins.push([require.resolve('postcss-url'), urlOption])
+        plugins.push([require.resolve('postcss-url'), urlOption.config || {}])
     }
 
     const appPath = process.cwd()
@@ -104,7 +104,7 @@ const getPostCssConfig = getConfig => {
         }
         try {
             const pluginPath = sync(pluginName, { basedir: appPath })
-            plugins.push(require(pluginPath)(pluginOption.config || {}))
+            plugins.push([pluginPath, pluginOption.config || {}])
         } catch (e) {
             const msg = e.code === 'MODULE_NOT_FOUND' ? `缺少 postcss 插件 "${pluginName}", 已忽略` : e
             console.log(msg)

--- a/packages/nextjs/postcss/index.js
+++ b/packages/nextjs/postcss/index.js
@@ -1,36 +1,119 @@
-const BASE_FONT_SIZE = 40
+// 同步 Taro 项目中 packages/taro-webpack5-runner/src/postcss/postcss.h5.ts 中的逻辑
+const path = require('path')
+const { merge, cloneDeep } = require('lodash')
+const { sync } = require('resolve')
 
-const withTaro = (designWidth, autoprefixerOption) => config => {
-    const plugins = config.plugins || []
+const platform = 'h5'
 
-    plugins.push(
-        [require.resolve('postcss-pxtorem'), {
-            rootValue: BASE_FONT_SIZE * designWidth / 640,
-            propWhiteList: [],
-            exclude: /(node_modules|tarojs-plugin-platform-nextjs)/
-        }]
-    )
+const defaultAutoprefixerOption = {
+    enable: true,
+    config: {
+        flexbox: 'no-2009'
+    }
+}
 
-    plugins.push(
-        [require.resolve('postcss-pxtorem'), {
-            rootValue: BASE_FONT_SIZE / 1.5,
-            propWhiteList: [],
-            exclude(file) {
-                return !/tarojs-plugin-platform-nextjs/.test(file)
-            }
-        }]
-    )
+const defaultPxtransformOption = {
+    enable: true,
+    config: {
+        platform
+    }
+}
 
-    if (autoprefixerOption) {
-        plugins.push(
-            [require.resolve('autoprefixer'), autoprefixerOption]
-        )
+const defaultConstparseOption = {
+  constants: [
+    {
+        key: 'taro-tabbar-height',
+        val: '50PX'
+    }
+  ],
+  platform
+}
+
+const defaultHtmltransformOption = {
+    enable: true,
+    config: {
+        platform,
+        removeCursorStyle: false
+    }
+}
+
+const defaultUrlOption = {
+    enable: true,
+    config: {
+        url: 'rebase'
+    }
+}
+
+function isEnable(option) {
+    return !option || !('enable' in option) || option.enable
+}
+
+function isNpmPkg(name) {
+    return !/^(\.|\/)/.test(name)
+}
+
+const getPostCssConfig = getConfig => {
+    // 处理 Taro 编译配置，同步 taro-service/src/Config.ts 中的逻辑
+    const config = getConfig(merge)
+    const { designWidth = 750, deviceRatio, h5 } = config
+
+    // 处理 postcss 配置，同步 taro-webpack5-runner/src/postcss/postcss.h5.ts 中的逻辑
+    const { autoprefixer, pxtransform, htmltransform, url, cssModules, ...rest } = h5.postcss
+
+    const plugins = []
+
+    plugins.push(require.resolve('postcss-import'))
+
+    const autoprefixerOption = merge({}, defaultAutoprefixerOption, autoprefixer)
+    if (isEnable(autoprefixerOption)) {
+        plugins.push([require.resolve('autoprefixer'), autoprefixerOption])
+    }
+    if (designWidth) {
+        defaultPxtransformOption.config.designWidth = designWidth
+    }
+    if (deviceRatio) {
+        defaultPxtransformOption.config.deviceRatio = deviceRatio
+    }
+    const pxtransformOption = merge({}, defaultPxtransformOption, pxtransform)
+    if (isEnable(pxtransformOption)) {
+        plugins.push([require.resolve('postcss-pxtransform'), pxtransformOption])
+    }
+    
+    const htmlTransformOption = merge({}, defaultHtmltransformOption, htmltransform)
+    if (isEnable(htmlTransformOption)) {
+        plugins.push([require.resolve('postcss-html-transform'), htmlTransformOption])
+    }
+
+    plugins.push([require.resolve('postcss-plugin-constparse'), cloneDeep(defaultConstparseOption)])
+
+    // TODO: 处理 postcss-alias 插件
+
+    const urlOption = merge({}, defaultUrlOption, url)
+    if (isEnable(urlOption)) {
+        plugins.push([require.resolve('postcss-url'), urlOption])
+    }
+
+    const appPath = process.cwd()
+    for (let [pluginName, pluginOption] of Object.entries(rest)) {
+        if (!isEnable(pluginOption)) {
+            break
+        }
+        if (!isNpmPkg(pluginName)) {
+            // local plugin
+            pluginName = path.join(appPath, pluginName)
+        }
+        try {
+            const pluginPath = sync(pluginName, { basedir: appPath })
+            plugins.push(require(pluginPath)(pluginOption.config || {}))
+        } catch (e) {
+            const msg = e.code === 'MODULE_NOT_FOUND' ? `缺少 postcss 插件 "${pluginName}", 已忽略` : e
+            console.log(msg)
+        }
     }
 
     return {
-        ...config,
         plugins
     }
 }
 
-module.exports = withTaro
+module.exports = getPostCssConfig

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -43,14 +43,19 @@ interface PluginOptions {
      * 是否打开浏览器
      */
     browser?: boolean
+    /**
+     * 指定构建时还需要包含的其他文件
+     */
+    extraFiles?: string[]
 }
 
 export default (ctx: IPluginContext, pluginOpts: PluginOptions) => {
     const {paths, helper, runOpts} = ctx
     const {appPath, outputPath, sourcePath, configPath} = paths
 
-    const runNextjs = pluginOpts.runNextjs == null && true
-    const browser = pluginOpts.browser == null && true
+    const runNextjs = pluginOpts.runNextjs ?? true
+    const browser = pluginOpts.browser ?? true
+    const extraFiles = pluginOpts.extraFiles ?? []
 
     ctx.registerCommand({
         name: 'start',
@@ -201,6 +206,7 @@ export default (ctx: IPluginContext, pluginOpts: PluginOptions) => {
 
             function scaffold() {
                 return es.merge(
+                    src(extraFiles, { cwd: appPath, base: '.' }).pipe(dest(outputPath)),
                     src(`${appPath}/*.d.ts`).pipe(dest(outputPath)),
                     src(`${sourcePath}/**`)
                         .pipe(filter(file => {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -10,6 +10,7 @@ import chalk from 'chalk'
 import spawn from 'cross-spawn'
 import * as babel from '@babel/core'
 import type {IPluginContext} from '@tarojs/service'
+import type { Stream } from 'stream'
 import {mergeTaroPages} from './taroUtils'
 import {
     getNextExportedFunctions,
@@ -205,8 +206,13 @@ export default (ctx: IPluginContext, pluginOpts: PluginOptions) => {
             createNextjsPages()
 
             function scaffold() {
+                const files: Stream[] = []
+                if (Array.isArray(extraFiles) && extraFiles.length) {
+                    files.push(src(extraFiles, { cwd: appPath, base: '.' }).pipe(dest(outputPath)))
+                }
+
                 return es.merge(
-                    src(extraFiles, { cwd: appPath, base: '.' }).pipe(dest(outputPath)),
+                    ...files,
                     src(`${appPath}/*.d.ts`).pipe(dest(outputPath)),
                     src(`${sourcePath}/**`)
                         .pipe(filter(file => {

--- a/packages/nextjs/template/postcss.config.ejs
+++ b/packages/nextjs/template/postcss.config.ejs
@@ -1,9 +1,0 @@
-const withTaro = require('tarojs-plugin-platform-nextjs/postcss')
-
-module.exports = withTaro(<%- designWidth %>, <%- autoprefixerOption %>)({
-    plugins: [
-        <%_ for (const {request, option} of plugins) { _%>
-        [require.resolve(<%- JSON.stringify(request) -%>), <%- JSON.stringify(option) -%>],
-        <%_ } _%>
-    ]
-})

--- a/packages/nextjs/template/postcss.config.js
+++ b/packages/nextjs/template/postcss.config.js
@@ -1,0 +1,5 @@
+const getPostCssConfig = require('tarojs-plugin-platform-nextjs/postcss')
+
+// 读取 Taro 的编译配置 https://docs.taro.zone/docs/config/
+// Taro SSR 插件暂不支持使用 ts 文件
+module.exports = getPostCssConfig(require('./config/index.js'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -12708,6 +12708,13 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
+is-core-module@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
+  dependencies:
+    has "^1.0.3"
+
 is-core-module@^2.5.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
   version "2.9.0"
   resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
@@ -19765,6 +19772,15 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
     is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.22.4:
+  version "1.22.4"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz#1dc40df46554cdaf8948a486a10f6ba1e2026c34"
+  integrity sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==
+  dependencies:
+    is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
Fix #1 

# 背景

当前 SSR 插件没有完整支持 Taro 的所有 postcss 配置，配置包含两部分：

1. 文档中的 autoprefixer、pxtransform、htmltransform、url、cssModules
2. Taro 代码中还能通过相对或绝对路径导入本地或外部的 postcss 插件

> 文档为：https://taro-docs.jd.com/docs/config-detail#h5postcss

无法在 Next.js 的 postcss 中直接导入 Taro 的 config 文件，只能通过序列化插件中的配置进行注入。
在 Taro 中，config 可以是 ESM，而 Next.js 的 postcss.config.js 文件只能是 CommonJS。postcss.config.js 必须导出配置对象，无法对 ESM 进行顶层 await。

Next.js 的 postcss.config.js 文件不可以使用 require() 导入 PostCSS 插件，只能通过字符串提供插件。

```js
module.exports = {
  plugins: [
    require.resolve("./postcss-tailwindcss-group"),
    require.resolve("tailwindcss"),
    require.resolve("autoprefixer"),
    [require.resolve("postcss-preset-env")], { stage: 3 }],
  ],
};
```

> 文档为：https://nextjs.org/docs/pages/building-your-application/configuring/post-css

# 方案一 ❌

我们不再依赖 Next.js 编译时执行 postcss，即配置 postcss.config.js，而是在 SSR 插件编译时执行 postcss。

不可行。没法处理 node_modules 中的外部依赖。

# 方案二 ❌

是否能直接在 next.config.js 中修改 Next.js 编译期间的 postcss 配置，或者增加 postcss 配置。

不可行。

# 方案三 ✅

折中方案，Taro config 只能是 CommonJS，以此可以在生成的 postcss.config.js 文件中直接引入 Taro config。

# 备注

处理同步 Taro 代码仓库中 taro-webpack5-runner/src/postcss/postcss.h5.ts 文件中的逻辑。

